### PR TITLE
fix: throw on invalid primitive types instead of returning undefined

### DIFF
--- a/src/Q.ts
+++ b/src/Q.ts
@@ -15,7 +15,7 @@ import {
   Term,
   TermValue,
   Range,
-  Spatial,
+  LSpatial,
   NotBase,
   RequiredBase,
   Required,
@@ -23,7 +23,7 @@ import {
   ProhibitedBase,
   AndBase,
   OrBase,
-  Glob,
+  LGlob,
   LString,
   LDate,
   LNumber,
@@ -64,7 +64,7 @@ export function LL<T extends Primitive>(value: T): Literal<T> {
   };
 }
 
-export function glob(value: string): Literal<Glob> {
+export function glob(value: string): Literal<LGlob> {
   return LL({
     type: 'glob',
     value,
@@ -74,7 +74,7 @@ export function glob(value: string): Literal<Glob> {
 export function defaultTerm(value: TermValue<LString>): Term<LString>;
 export function defaultTerm(value: TermValue<LNumber>): Term<LNumber>;
 export function defaultTerm(value: TermValue<LDate>): Term<LDate>;
-export function defaultTerm(value: TermValue<Spatial>): Term<Spatial>;
+export function defaultTerm(value: TermValue<LSpatial>): Term<LSpatial>;
 export function defaultTerm<T extends Primitive>(value: TermValue<T>): Term<T> {
   return {
     type: 'term',
@@ -93,8 +93,8 @@ export function term(
 export function term(field: string, value: TermValue<LDate>): NamedTerm<LDate>;
 export function term(
   field: string,
-  value: TermValue<Spatial>
-): NamedTerm<Spatial>;
+  value: TermValue<LSpatial>
+): NamedTerm<LSpatial>;
 export function term<T extends Primitive>(
   field: string,
   value: TermValue<T>
@@ -182,7 +182,7 @@ export function closedRange<T extends RangedPrimitive>(
 export function not(rhs: TermValue<LString>): NotTerm<LString>;
 export function not(rhs: TermValue<LNumber>): NotTerm<LNumber>;
 export function not(rhs: TermValue<LDate>): NotTerm<LDate>;
-export function not(rhs: TermValue<Spatial>): NotTerm<Spatial>;
+export function not(rhs: TermValue<LSpatial>): NotTerm<LSpatial>;
 export function not(rhs: Clause): Not;
 export function not<U>(rhs: U): NotBase<U> {
   return {
@@ -194,7 +194,7 @@ export function not<U>(rhs: U): NotBase<U> {
 export function required(rhs: TermValue<LString>): RequiredTerm<LString>;
 export function required(rhs: TermValue<LNumber>): RequiredTerm<LNumber>;
 export function required(rhs: TermValue<LDate>): RequiredTerm<LDate>;
-export function required(rhs: TermValue<Spatial>): RequiredTerm<Spatial>;
+export function required(rhs: TermValue<LSpatial>): RequiredTerm<LSpatial>;
 export function required(rhs: Clause): Required;
 export function required<U>(rhs: U): RequiredBase<U> {
   return {
@@ -206,7 +206,7 @@ export function required<U>(rhs: U): RequiredBase<U> {
 export function prohibited(rhs: TermValue<LString>): ProhibitedTerm<LString>;
 export function prohibited(rhs: TermValue<LNumber>): ProhibitedTerm<LNumber>;
 export function prohibited(rhs: TermValue<LDate>): ProhibitedTerm<LDate>;
-export function prohibited(rhs: TermValue<Spatial>): ProhibitedTerm<Spatial>;
+export function prohibited(rhs: TermValue<LSpatial>): ProhibitedTerm<LSpatial>;
 export function prohibited(rhs: Clause): Prohibited;
 export function prohibited<U>(rhs: U): ProhibitedBase<U> {
   return {
@@ -226,7 +226,7 @@ export function constantScore(lhs: Clause, rhs: number): ConstantScore {
 export function and(...more: Array<TermValue<LString>>): AndTerm<LString>;
 export function and(...more: Array<TermValue<LNumber>>): AndTerm<LNumber>;
 export function and(...more: Array<TermValue<LDate>>): AndTerm<LDate>;
-export function and(...more: Array<TermValue<Spatial>>): AndTerm<Spatial>;
+export function and(...more: Array<TermValue<LSpatial>>): AndTerm<LSpatial>;
 export function and<T>(...more: Clause[]): And;
 export function and<U>(...more: U[]): AndBase<U> {
   return {
@@ -238,7 +238,7 @@ export function and<U>(...more: U[]): AndBase<U> {
 export function or(...more: Array<TermValue<LString>>): OrTerm<LString>;
 export function or(...more: Array<TermValue<LNumber>>): OrTerm<LNumber>;
 export function or(...more: Array<TermValue<LDate>>): OrTerm<LDate>;
-export function or(...more: Array<TermValue<Spatial>>): OrTerm<Spatial>;
+export function or(...more: Array<TermValue<LSpatial>>): OrTerm<LSpatial>;
 export function or(...more: Clause[]): Or;
 export function or<U>(...more: U[]): OrBase<U> {
   return {

--- a/src/query.ts
+++ b/src/query.ts
@@ -5,7 +5,7 @@ import { either } from 'fp-ts/lib/Either';
 import {
   Primitive,
   Range,
-  Spatial,
+  LSpatial,
   RangedPrimitive,
   QueryElement,
 } from './types';
@@ -34,7 +34,7 @@ function nope(): never {
   throw new Error('unsupported');
 }
 
-function wkt(g: Spatial['value']['geom']): WKT {
+function wkt(g: LSpatial['value']['geom']): WKT {
   const d = wktio.WKTStringFromGeometry.decode(g);
   /* istanbul ignore if */
   if (!isRight(d)) {
@@ -60,7 +60,7 @@ function toLiteralString<T extends Primitive>(
       return (c as Date).toISOString();
     case 'spatial':
       return quoteString(
-        `${(c as Spatial['value']).op}(${wkt((c as Spatial['value']).geom)})`
+        `${(c as LSpatial['value']).op}(${wkt((c as LSpatial['value']).geom)})`
       );
     case 'glob':
       return escapedGlob(c as string);

--- a/src/spatial.ts
+++ b/src/spatial.ts
@@ -1,5 +1,5 @@
 import {
-  Spatial,
+  LSpatial,
   Intersects,
   IsWithin,
   Contains,
@@ -8,7 +8,7 @@ import {
 } from './types';
 import * as geojson from '@holvonix-open/geojson-io-ts';
 
-function spatialPredicate<T extends Spatial['value']['op']>(
+function spatialPredicate<T extends LSpatial['value']['op']>(
   op: T,
   value: geojson.GeometryObject
 ) {

--- a/test/test-query.ts
+++ b/test/test-query.ts
@@ -93,7 +93,7 @@ describe('query', () => {
       }
       it('primitives', async () => {
         const gg = (await fuzzRegistry()).exampleGenerator(
-          union([tt.Spatial, tt.LNumber, tt.LDate, tt.LString, tt.Glob])
+          union([tt.LSpatial, tt.LNumber, tt.LDate, tt.LString, tt.LGlob])
         );
         verifyEncoderThrows(gg as ExampleGenerator<tt.QueryElement>);
       });

--- a/test/test-types.ts
+++ b/test/test-types.ts
@@ -2,8 +2,15 @@ import * as assert from 'assert';
 import * as tt from '../src/types';
 import { isRight, isLeft } from 'fp-ts/lib/Either';
 import { closedRange } from '../src/Q';
+import * as t from 'io-ts';
+import { Q } from '../src';
+import { Polygon } from '@holvonix-open/geojson-io-ts';
 
 describe('types', () => {
+  const geo: Polygon = {
+    type: 'Polygon',
+    coordinates: [[[20, 30], [0, 0], [20, 30]]],
+  };
   describe('codec verification', () => {
     describe('Range', () => {
       it('LNumber', () => {
@@ -25,6 +32,238 @@ describe('types', () => {
         assert.ok(isLeft(r.decode(closedRange(100, 300))));
         assert.ok(isLeft(r.decode(closedRange('a', 'bb'))));
         assert.ok(isRight(r.decode(closedRange(undefined, new Date()))));
+      });
+
+      it('throws on invalid primitive', () => {
+        assert.throws(
+          () => tt.Range((t.string as unknown) as typeof tt.LString),
+          /SQM004/
+        );
+      });
+      it('throws on non-ranged primitive', () => {
+        assert.throws(
+          () => tt.Range((tt.LSpatial as unknown) as typeof tt.LString),
+          /SQM004/
+        );
+      });
+      it('throws on spatial subtype', () => {
+        assert.throws(
+          () => tt.Range((tt.Intersects as unknown) as typeof tt.LString),
+          /SQM005/
+        );
+      });
+    });
+
+    describe('Literal', () => {
+      it('LNumber', () => {
+        const r = tt.Literal(tt.LNumber);
+        assert.ok(isRight(r.decode(Q.L(2))));
+        assert.ok(isLeft(r.decode(Q.L('2'))));
+        assert.ok(isLeft(r.decode(Q.glob('2'))));
+        assert.ok(isLeft(r.decode(Q.L(new Date()))));
+        assert.ok(isLeft(r.decode(Q.spatial.contains(geo))));
+        assert.ok(isLeft(r.decode(closedRange('a', 'bb'))));
+        assert.ok(isLeft(r.decode(closedRange(undefined, new Date()))));
+      });
+
+      it('LString', () => {
+        const r = tt.Literal(tt.LString);
+        assert.ok(isLeft(r.decode(Q.L(2))));
+        assert.ok(isRight(r.decode(Q.L('2'))));
+        assert.ok(isLeft(r.decode(Q.glob('2'))));
+        assert.ok(isLeft(r.decode(Q.L(new Date()))));
+        assert.ok(isLeft(r.decode(Q.spatial.contains(geo))));
+        assert.ok(isLeft(r.decode(closedRange('a', 'bb'))));
+        assert.ok(isLeft(r.decode(closedRange(undefined, new Date()))));
+      });
+
+      it('LGlob', () => {
+        const r = tt.Literal(tt.LGlob);
+        assert.ok(isLeft(r.decode(Q.L(2))));
+        assert.ok(isLeft(r.decode(Q.L('2'))));
+        assert.ok(isRight(r.decode(Q.glob('2'))));
+        assert.ok(isLeft(r.decode(Q.L(new Date()))));
+        assert.ok(isLeft(r.decode(Q.spatial.contains(geo))));
+        assert.ok(isLeft(r.decode(closedRange('a', 'bb'))));
+        assert.ok(isLeft(r.decode(closedRange(undefined, new Date()))));
+      });
+
+      it('LSpatial', () => {
+        const r = tt.Literal(tt.LSpatial);
+        assert.ok(isLeft(r.decode(Q.L(2))));
+        assert.ok(isLeft(r.decode(Q.L('2'))));
+        assert.ok(isLeft(r.decode(Q.glob('2'))));
+        assert.ok(isLeft(r.decode(Q.L(new Date()))));
+        assert.ok(isRight(r.decode(Q.spatial.contains(geo))));
+        assert.ok(isLeft(r.decode(closedRange('a', 'bb'))));
+        assert.ok(isLeft(r.decode(closedRange(undefined, new Date()))));
+      });
+
+      it('LDate', () => {
+        const r = tt.Literal(tt.LDate);
+        assert.ok(isLeft(r.decode(Q.L(2))));
+        assert.ok(isLeft(r.decode(Q.L('2'))));
+        assert.ok(isLeft(r.decode(Q.glob('2'))));
+        assert.ok(isRight(r.decode(Q.L(new Date()))));
+        assert.ok(isLeft(r.decode(Q.spatial.contains(geo))));
+        assert.ok(isLeft(r.decode(closedRange('a', 'bb'))));
+        assert.ok(isLeft(r.decode(closedRange(undefined, new Date()))));
+      });
+
+      it('throws on invalid primitive', () => {
+        assert.throws(
+          () => tt.Literal((t.string as unknown) as typeof tt.LString),
+          /SQM004/
+        );
+      });
+      it('throws on spatial subtype', () => {
+        assert.throws(
+          () => tt.Literal((tt.Intersects as unknown) as typeof tt.LString),
+          /SQM005/
+        );
+      });
+    });
+
+    describe('TermValue', () => {
+      it('throws on invalid primitive', () => {
+        assert.throws(
+          () => tt.TermValue((t.string as unknown) as typeof tt.LString),
+          /SQM004/
+        );
+      });
+      it('throws on spatial subtype', () => {
+        assert.throws(
+          () => tt.TermValue((tt.Intersects as unknown) as typeof tt.LString),
+          /SQM005/
+        );
+      });
+    });
+
+    describe('NonPrimitiveTermValue', () => {
+      it('throws on invalid primitive', () => {
+        assert.throws(
+          () =>
+            tt.NonPrimitiveTermValue(
+              (t.string as unknown) as typeof tt.LString
+            ),
+          /SQM004/
+        );
+      });
+      it('throws on spatial subtype', () => {
+        assert.throws(
+          () =>
+            tt.NonPrimitiveTermValue(
+              (tt.Intersects as unknown) as typeof tt.LString
+            ),
+          /SQM005/
+        );
+      });
+    });
+
+    describe('Term', () => {
+      it('throws on invalid primitive', () => {
+        assert.throws(
+          () => tt.Term((t.string as unknown) as typeof tt.LString),
+          /SQM004/
+        );
+      });
+      it('throws on spatial subtype', () => {
+        assert.throws(
+          () => tt.Term((tt.Intersects as unknown) as typeof tt.LString),
+          /SQM005/
+        );
+      });
+    });
+
+    describe('NamedTerm', () => {
+      it('throws on invalid primitive', () => {
+        assert.throws(
+          () => tt.NamedTerm((t.string as unknown) as typeof tt.LString),
+          /SQM004/
+        );
+      });
+      it('throws on spatial subtype', () => {
+        assert.throws(
+          () => tt.NamedTerm((tt.Intersects as unknown) as typeof tt.LString),
+          /SQM005/
+        );
+      });
+    });
+
+    describe('AndTerm', () => {
+      it('throws on invalid primitive', () => {
+        assert.throws(
+          () => tt.AndTerm((t.string as unknown) as typeof tt.LString),
+          /SQM004/
+        );
+      });
+      it('throws on spatial subtype', () => {
+        assert.throws(
+          () => tt.AndTerm((tt.Intersects as unknown) as typeof tt.LString),
+          /SQM005/
+        );
+      });
+    });
+
+    describe('OrTerm', () => {
+      it('throws on invalid primitive', () => {
+        assert.throws(
+          () => tt.OrTerm((t.string as unknown) as typeof tt.LString),
+          /SQM004/
+        );
+      });
+      it('throws on spatial subtype', () => {
+        assert.throws(
+          () => tt.OrTerm((tt.Intersects as unknown) as typeof tt.LString),
+          /SQM005/
+        );
+      });
+    });
+
+    describe('NotTerm', () => {
+      it('throws on invalid primitive', () => {
+        assert.throws(
+          () => tt.NotTerm((t.string as unknown) as typeof tt.LString),
+          /SQM004/
+        );
+      });
+      it('throws on spatial subtype', () => {
+        assert.throws(
+          () => tt.NotTerm((tt.Intersects as unknown) as typeof tt.LString),
+          /SQM005/
+        );
+      });
+    });
+
+    describe('RequiredTerm', () => {
+      it('throws on invalid primitive', () => {
+        assert.throws(
+          () => tt.RequiredTerm((t.string as unknown) as typeof tt.LString),
+          /SQM004/
+        );
+      });
+      it('throws on spatial subtype', () => {
+        assert.throws(
+          () =>
+            tt.RequiredTerm((tt.Intersects as unknown) as typeof tt.LString),
+          /SQM005/
+        );
+      });
+    });
+
+    describe('ProhibitedTerm', () => {
+      it('throws on invalid primitive', () => {
+        assert.throws(
+          () => tt.ProhibitedTerm((t.string as unknown) as typeof tt.LString),
+          /SQM004/
+        );
+      });
+      it('throws on spatial subtype', () => {
+        assert.throws(
+          () =>
+            tt.ProhibitedTerm((tt.Intersects as unknown) as typeof tt.LString),
+          /SQM005/
+        );
       });
     });
   });


### PR DESCRIPTION
BREAKING CHANGE: `Spatial` renamed to `LSpatial`

BREAKING CHANGE: `Glob` renamed to `LGlob`
